### PR TITLE
Fix broken table rendering in grafana chart README.md

### DIFF
--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -247,7 +247,6 @@ This version requires Helm >= 3.1.0.
 | `serviceMonitor.scrapeTimeout`            | Timeout after which the scrape is ended       | `30s`                                                   |
 | `serviceMonitor.relabelings`              | RelabelConfigs to apply to samples before scraping.     | `[]`                                      |
 | `serviceMonitor.metricRelabelings`        | MetricRelabelConfigs to apply to samples before ingestion.  | `[]`                                      |
-
 | `revisionHistoryLimit`                    | Number of old ReplicaSets to retain           | `10`                                                    |
 | `imageRenderer.enabled`                    | Enable the image-renderer deployment & service                                     | `false`                          |
 | `imageRenderer.image.repository`           | image-renderer Image repository                                                    | `grafana/grafana-image-renderer` |


### PR DESCRIPTION
The values table in the grafana chart README was broken.

It appears that markdown table rendering does not like empty lines between table rows and all table rows following the empty line simply got mangled up in a single paragraph.

This PR fixes that typo by removing an empty line from the README.md file